### PR TITLE
Version tag invisible in the Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ vhdl_tb (or its alias tbgen) generates a VHDL testbench from an file containing 
 The generated code is similar to what vhdl-mode for emacs can generate.
 
 To build the Ruby gem, type :
+```bash
 gem build vhdl_tb.gemspec
+```
 
 To install :
+```bash
 gem install --local vhdl_tb-<VERSION>.gem
+```
 
 More to come later.


### PR DESCRIPTION
```bash
my_file-<version>  # Seen as my_file- in Markdown
myfile-\<version\> # Seen as my_file-<version> in Markdown
```
By the way, I preferred to put commands in code blocks